### PR TITLE
Fix potential format string pollution

### DIFF
--- a/src/earwigbot/wiki/copyvios/workers.py
+++ b/src/earwigbot/wiki/copyvios/workers.py
@@ -493,12 +493,13 @@ class CopyvioWorkspace:
 
                     key = ".".join(urlparse(url).netloc.split(".")[-2:])
 
-                logmsg = f"enqueue(): %s {key} -> {url}"
+                matchup = f"{key} -> {url}"
+                logmsg = f"enqueue(): %s %s"
                 if key in self._queues.sites:
-                    self._logger.debug(logmsg % "append")
+                    self._logger.debug(logmsg % ("append", matchup))
                     self._queues.sites[key].append(source)
                 else:
-                    self._logger.debug(logmsg % "new")
+                    self._logger.debug(logmsg % ("new", matchup))
                     q: SourceQueue = collections.deque()
                     q.append(source)
                     self._queues.sites[key] = q


### PR DESCRIPTION
Some URLs may have a format string pattern in them, which will cause the argument count to be incorrect and crash the enqueue. This locks in the key and URL to be plain strings and completely uninterpreted to avoid this issue.

This currently appears when trying to run the copyvio detector on [User:Chlod/sandbox](https://en.wikipedia.org/wiki/User:Chlod/sandbox?oldid=1352062245): https://copyvios-dev.toolforge.org/?lang=en&project=wikipedia&title=User%3AChlod%2Fsandbox&oldid=1352062245&action=search&use_engine=1&use_links=1&turnitin=0